### PR TITLE
Use https://adoptium.net/ instead of https://adoptium.net/releases.html

### DIFF
--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -19,7 +19,7 @@ Install the right package
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
 * Azul: https://www.azul.com/downloads/?version=java-17-stsarchitecture=x86-64-bit&package=jre#download-openjdk
-* Eclipse Adoptium: https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+* Eclipse Adoptium: https://adoptium.net/?variant=openjdk17&jvmVariant=hotspot
 * Microsoft OpenJDK: https://docs.microsoft.com/en-gb/java/openjdk/download
 * Oracle: https://www.oracle.com/java/technologies/downloads/
 


### PR DESCRIPTION
The page at `/` is potentially less confusing for users, as it provides a single button instead of the list of multiple different options provided by `/releases.html`.