### PR TITLE
fix 'Unbuntu' to 'Ubuntu'

### DIFF
--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -9,7 +9,7 @@ For Minecraft 1.17 you need to use at least Java 16, for 1.18 you need to use Ja
 
 Install the right package
 
-* Unbuntu/Debian derivatives: `openjdk-17-jre`
+* Ubuntu/Debian derivatives: `openjdk-17-jre`
 * Arch `jre17-openjdk`
 * Fedora `java-latest-openjdk`
 * OpenSUSE: `java-17-openjdk` (currently only in Tumbleweed)


### PR DESCRIPTION
fix the ubuntu linux typo in the wiki