### PR TITLE
All kinds of changes on -ijava

### DIFF
--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -23,7 +23,7 @@ Install the right package
 * Ubuntu/Debian derivatives: `openjdk-17-jre`
 * Arch `jre17-openjdk`
 * Fedora `java-17-openjdk`
-* OpenSUSE: `java-17-openjdk` (currently only in Tumbleweed)
+* OpenSUSE: `java-17-openjdk`
 
 Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
 

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -18,8 +18,9 @@ Install the right package
 
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
-* Azul: https://www.azul.com/downloads/?version=java-17-lts&architecture=x86-64-bit&package=jre#download-openjdk
-* Eclipse Adoptium: https://adoptium.net/?variant=openjdk17&jvmVariant=hotspot
+* Azul: https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre
+* Eclipse Temurin: https://adoptium.net/temurin/releases/?version=17
+  * Select in the dropdowns "Windows" "x64" "JRE" and "17"
 * Microsoft OpenJDK: https://docs.microsoft.com/en-gb/java/openjdk/download
 * Oracle: https://www.oracle.com/java/technologies/downloads/#java17
 
@@ -59,18 +60,11 @@ Common issue is that people install only the headless version, and then it doesn
 
 Note: There is an exception when using some poorly supported/unsupported old integrated GPUs from Intel. See [[Unsupported-Intel-GPUs]] for details.
 
-### 64-bit
-* Go to https://www.java.com/en/download/manual.jsp
-* Download the `Windows Offline (64-bit)` installer, as shown below.
-![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
-* Install it.
-
-### 32-bit
-* Go to https://www.java.com/en/download/manual.jsp
-* Download the `Windows Offline` installer.
-* Install it.
-
-You will be limited to roughly 1500MB Java heap size, which is not big enough for mods in most cases.
+* Eclipse Temurin: https://adoptium.net/temurin/releases/?version=8
+  * Select in the dropdowns "Windows" "x64" "JRE" and "8"
+* Azul: https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre
+* Java.com: https://www.java.com/en/download/manual.jsp 
+  * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.
 
 ## macOS
 * Go to https://www.java.com/en/download/manual.jsp

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -2,17 +2,7 @@ Generally you should use Java with the same architecture as your CPU. There are 
 If you don't know which one and how to get it, read on. After you installed the correct version make sure [to select it](#setting-up-java-in-multimc).
 
 # Minecraft 1.17 and newer
-
-For Minecraft 1.17 you need to use at least Java 16, for 1.18 you need to use Java 17 so it's easiest to just install Java 17 for both.
-
-## Linux
-
-Install the right package
-
-* Ubuntu/Debian derivatives: `openjdk-17-jre`
-* Arch `jre17-openjdk`
-* Fedora `java-latest-openjdk`
-* OpenSUSE: `java-17-openjdk` (currently only in Tumbleweed)
+Use of Java 17 is recommended and encouraged for best compatibility.
 
 ## Windows
 
@@ -28,36 +18,41 @@ Azul: https://www.azul.com/downloads/?version=java-17-lts&os=windows&architectur
 * Oracle: https://www.oracle.com/java/technologies/downloads/#java17
 </details>
 
+## Linux
+* Install the right package
+
+  **Ubuntu/Debian derivatives**
+
+  ```
+  # apt-get install openjdk-17-jre
+  ```
+
+  **Arch**
+
+  ```
+  # pacman -Syu jre17-openjdk
+  ```
+
+  **RPM-based distributions**
+
+  ```
+  # yum install java-17-openjdk
+  ```
+
+Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
+
 ## macOS
 
-- Homebrew: `openjdk@17`
-- Macports: `openjdk17`
+Azul: https://www.azul.com/downloads/?version=java-17-lts&os=macos&architecture=x86-64-bit&package=jre
+For least amount of issues, choose **.dmg** download.
+
+**Native ARM Java is currently not supported on MultiMC.**
 
 Alternatively the Windows links above usually also provide macOS and Linux versions. On M1 Macs you need to make sure to get the x64 packages, native Arm Java is currently not supported!
-
 
 # Minecraft 1.16 and older
 
 The right Java version to use is Java 8
-
-## Linux
-
-* Install the right package
-
-  **Ubuntu/Debian derivatives**
-  ```
-  # apt-get install openjdk-8-jre
-  ```
-  **Arch**
-  ```
-  # pacman -Syu jre8-openjdk
-  ```
-  **RPM-based distributions**
-  ```
-  # yum install java-1.8.0-openjdk
-  ```
-
-Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
 
 ## Windows
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
@@ -74,6 +69,31 @@ Azul: https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture
   * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.
 ![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
 </details>
+
+## Linux
+
+* Install the right package
+
+  **Ubuntu/Debian derivatives**
+
+  ```
+  # apt-get install openjdk-8-jre
+  ```
+
+  **Arch**
+
+  ```
+  # pacman -Syu jre8-openjdk
+  ```
+
+  **RPM-based distributions**
+
+  ```
+  # yum install java-1.8.0-openjdk
+  ```
+
+Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
+
 
 ## macOS
 * Go to https://www.java.com/en/download/manual.jsp

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -2,6 +2,7 @@ Generally you should use Java with the same architecture as your CPU. There are 
 If you don't know which one and how to get it, read on. After you installed the correct version make sure [to select it](#setting-up-java-in-multimc).
 
 # Minecraft 1.17 and newer
+
 Use of Java 17 is recommended and encouraged for best compatibility.
 
 ## Windows
@@ -19,6 +20,7 @@ Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=windows&architectu
 </details>
 
 ## Linux
+
 Install the right package
 * Ubuntu/Debian derivatives: `openjdk-17-jre`
 * Arch `jre17-openjdk`
@@ -41,6 +43,7 @@ Alternatively the Windows links above usually also provide macOS and Linux versi
 The right Java version to use is Java 8
 
 ## Windows
+
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
 Note: There is an exception when using some poorly supported/unsupported old integrated GPUs from Intel. See [[Unsupported-Intel-GPUs]] for details.

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -8,42 +8,28 @@ Use of Java 17 is recommended and encouraged for best compatibility.
 
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
-Azul: https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre
+Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre>
 <details>
 <summary>Other Distributions</summary>
 
-* Eclipse Temurin: https://adoptium.net/temurin/releases/?version=17
+* Eclipse Temurin: <https://adoptium.net/temurin/releases/?version=17>
   * Select in the dropdowns "Windows" "x64" "JRE" and "17"
-* Microsoft OpenJDK: https://docs.microsoft.com/en-gb/java/openjdk/download
-* Oracle: https://www.oracle.com/java/technologies/downloads/#java17
+* Microsoft OpenJDK: <https://docs.microsoft.com/en-gb/java/openjdk/download>
+* Oracle: <https://www.oracle.com/java/technologies/downloads/#java17>
 </details>
 
 ## Linux
-* Install the right package
-
-  **Ubuntu/Debian derivatives**
-
-  ```
-  # apt-get install openjdk-17-jre
-  ```
-
-  **Arch**
-
-  ```
-  # pacman -Syu jre17-openjdk
-  ```
-
-  **RPM-based distributions**
-
-  ```
-  # yum install java-17-openjdk
-  ```
+Install the right package
+* Ubuntu/Debian derivatives: `openjdk-17-jre`
+* Arch `jre17-openjdk`
+* Fedora `java-17-openjdk`
+* OpenSUSE: `java-17-openjdk` (currently only in Tumbleweed)
 
 Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
 
 ## macOS
 
-Azul: https://www.azul.com/downloads/?version=java-17-lts&os=macos&architecture=x86-64-bit&package=jre
+Azul: <https://www.azul.com/downloads/?version=java-17-lts&os=macos&architecture=x86-64-bit&package=jre>
 For least amount of issues, choose **.dmg** download.
 
 **Native ARM Java is currently not supported on MultiMC.**
@@ -59,45 +45,32 @@ Pick the JRE versions and make sure to match the architecture with your system, 
 
 Note: There is an exception when using some poorly supported/unsupported old integrated GPUs from Intel. See [[Unsupported-Intel-GPUs]] for details.
 
-Azul: https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre
+Azul: <https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre>
 <details>
   <summary>Other Distributions</summary>
 
-* Eclipse Temurin: https://adoptium.net/temurin/releases/?version=8
+* Eclipse Temurin: <https://adoptium.net/temurin/releases/?version=8>
   * Select in the dropdowns "Windows" "x64" "JRE" and "8"
-* Java.com: https://www.java.com/en/download/manual.jsp 
+* Java.com: <https://www.java.com/en/download/manual.jsp>
   * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.
 ![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
 </details>
 
 ## Linux
 
-* Install the right package
+Install the right package
 
-  **Ubuntu/Debian derivatives**
-
-  ```
-  # apt-get install openjdk-8-jre
-  ```
-
-  **Arch**
-
-  ```
-  # pacman -Syu jre8-openjdk
-  ```
-
-  **RPM-based distributions**
-
-  ```
-  # yum install java-1.8.0-openjdk
-  ```
+* Ubuntu/Debian derivatives: `openjdk-8-jre`
+* Arch `jre8-openjdk`
+* Fedora `java-1.8.0-openjdk`
+* OpenSUSE: `java-1.8.0-openjdk`
 
 Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
 
-
 ## macOS
-* Go to https://www.java.com/en/download/manual.jsp
-* Download the `Mac OS X ` package.
+
+* Go to <https://www.java.com/en/download/manual.jsp>
+* Download the `Mac OS X` package.
 * Install it.
 
 # Setting up Java in MultiMC

--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -18,12 +18,15 @@ Install the right package
 
 Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
-* Azul: https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre
+Azul: https://www.azul.com/downloads/?version=java-17-lts&os=windows&architecture=x86-64-bit&package=jre
+<details>
+<summary>Other Distributions</summary>
+
 * Eclipse Temurin: https://adoptium.net/temurin/releases/?version=17
   * Select in the dropdowns "Windows" "x64" "JRE" and "17"
 * Microsoft OpenJDK: https://docs.microsoft.com/en-gb/java/openjdk/download
 * Oracle: https://www.oracle.com/java/technologies/downloads/#java17
-
+</details>
 
 ## macOS
 
@@ -57,14 +60,20 @@ The right Java version to use is Java 8
 Common issue is that people install only the headless version, and then it doesn't work. Make sure you have the full desktop version. Headless is for servers.
 
 ## Windows
+Pick the JRE versions and make sure to match the architecture with your system, usually x64 (64-bit)
 
 Note: There is an exception when using some poorly supported/unsupported old integrated GPUs from Intel. See [[Unsupported-Intel-GPUs]] for details.
 
+Azul: https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre
+<details>
+  <summary>Other Distributions</summary>
+
 * Eclipse Temurin: https://adoptium.net/temurin/releases/?version=8
   * Select in the dropdowns "Windows" "x64" "JRE" and "8"
-* Azul: https://www.azul.com/downloads/?version=java-8-lts&os=windows&architecture=x86-64-bit&package=jre
 * Java.com: https://www.java.com/en/download/manual.jsp 
   * Make sure to download only the "_Windows Offline (x64)_" installer as Online can cause installation issues.
+![](https://cdn.discordapp.com/attachments/404818598541000704/681278632811036714/correct-windows-java.png)
+</details>
 
 ## macOS
 * Go to https://www.java.com/en/download/manual.jsp


### PR DESCRIPTION
Renamed Eclipse Adoptium to Eclipse Temurin as that's the name of the Java distribution.
Added filtering guidance to reduce chance for user error.

Added Windows specific filtering to Azul links.

Updated the various links to point to their current locations.

Added other distributions for Java 8 on Windows.
Completely removed the 32bit section on Java 8 for Windows, as running that causes more issues than it's worth.