### PR TITLE
NOISSUE: Update Java 21 to indicate using .MSI

### DIFF
--- a/Using-the-right-Java.md
+++ b/Using-the-right-Java.md
@@ -5,6 +5,8 @@ If you don't know which one and how to get it, read on. After you installed the 
 
 ### **Minecraft 1.20.5 and newer (Java 21)**
 
+**Make sure to download the .msi installer!**
+
 Eclipse Temurin: <https://adoptium.net/temurin/releases/?os=windows&arch=x64&package=jre&version=21>
 
 &nbsp;


### PR DESCRIPTION
This updates the wording for Java 21 in the using the right java wiki page to advise them to download the MSI file.